### PR TITLE
action: don't bother capturing stderr

### DIFF
--- a/action.py
+++ b/action.py
@@ -108,10 +108,9 @@ def main():
         env={
             "GH_TOKEN": token,
         },
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=None,
     )
-
-    sys.stderr.buffer.write(result.stderr)
 
     if advanced_security:
         sarif = _tmpfile()


### PR DESCRIPTION
Stream it via the inherited parent `stderr` instead, since that's all we do with it.