### PR TITLE
fix: allow version prefix of `v`

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -35,7 +35,7 @@ installed docker || die "Cannot run this action without Docker"
 
 output="${RUNNER_TEMP}/zizmor"
 
-version_regex='^[0-9]+\.[0-9]+\.[0-9]+$'
+version_regex='^v?[0-9]+\.[0-9]+\.[0-9]+$'
 
 [[ "${GHA_ZIZMOR_VERSION}" == "latest" || "${GHA_ZIZMOR_VERSION}" =~ $version_regex ]] \
     || die "'version' must be 'latest' or an exact X.Y.Z version"
@@ -52,7 +52,7 @@ fi
 [[ -n "${GHA_ZIZMOR_MIN_SEVERITY}" ]] && arguments+=("--min-severity=${GHA_ZIZMOR_MIN_SEVERITY}")
 [[ -n "${GHA_ZIZMOR_MIN_CONFIDENCE}" ]] && arguments+=("--min-confidence=${GHA_ZIZMOR_MIN_CONFIDENCE}")
 
-image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION}"
+image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION#v}"
 
 # Notes:
 # - We run the container with ${GITHUB_WORKSPACE} mounted as /workspace


### PR DESCRIPTION
Allow the `version` input to be prefixed with `v`.

---

The README states that the version can be prefixed with `v`:

https://github.com/zizmorcore/zizmor-action/blob/c17832b972c15fd5f3d5065a7e16ad761a0a10d2/README.md?plain=1#L196-L200

However, [this doesn't actually work](https://github.com/martincostello/costellobot/actions/runs/16908733255/job/47904592723?pr=2623#step:6:32):

```yaml
    - name: Lint workflows with zizmor
      uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
      with:
        persona: pedantic
        # renovate: datasource=github-releases depName=zizmor packageName=zizmorcore/zizmor
        version: 'v1.11.0'
```

```text
Error: 'version' must be 'latest' or an exact X.Y.Z version
Error: Process completed with exit code 1.
```

Fixed by allowing an optional `v` at the start of the regex and then trimming it off the value before use.
