### PR TITLE
feat: add support for `color` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ when [`advanced-security`](#advanced-security) is enabled.
 will not upload results to Advanced Security, and will instead
 print them to the console.
 
+### `color`
+
+*Default*: `true`
+
+`color` controls whether `zizmor-action` outputs colorized log output.
+
 ## Permissions
 
 `zizmor-action` requires different permissions depending on how you use it.

--- a/action.sh
+++ b/action.sh
@@ -51,7 +51,7 @@ fi
 [[ "${GHA_ZIZMOR_ONLINE_AUDITS}" == "true" ]] || arguments+=("--no-online-audits")
 [[ -n "${GHA_ZIZMOR_MIN_SEVERITY}" ]] && arguments+=("--min-severity=${GHA_ZIZMOR_MIN_SEVERITY}")
 [[ -n "${GHA_ZIZMOR_MIN_CONFIDENCE}" ]] && arguments+=("--min-confidence=${GHA_ZIZMOR_MIN_CONFIDENCE}")
-[[ -n "${GHA_ZIZMOR_COLOR}"]] && arguments+=("--color=${GHA_ZIZMOR_COLOR}")
+[[ -n "${GHA_ZIZMOR_COLOR}" ]] && arguments+=("--color=${GHA_ZIZMOR_COLOR}")
 
 image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION#v}"
 

--- a/action.sh
+++ b/action.sh
@@ -51,7 +51,7 @@ fi
 [[ "${GHA_ZIZMOR_ONLINE_AUDITS}" == "true" ]] || arguments+=("--no-online-audits")
 [[ -n "${GHA_ZIZMOR_MIN_SEVERITY}" ]] && arguments+=("--min-severity=${GHA_ZIZMOR_MIN_SEVERITY}")
 [[ -n "${GHA_ZIZMOR_MIN_CONFIDENCE}" ]] && arguments+=("--min-confidence=${GHA_ZIZMOR_MIN_CONFIDENCE}")
-[[ -n "${GHA_ZIZMOR_COLOR}" ]] && arguments+=("--color=${GHA_ZIZMOR_COLOR}")
+[[ "${GHA_ZIZMOR_COLOR}" == "true" ]] && arguments+=("--color=always") || arguments+=("--color=never")
 
 image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION#v}"
 

--- a/action.sh
+++ b/action.sh
@@ -51,6 +51,7 @@ fi
 [[ "${GHA_ZIZMOR_ONLINE_AUDITS}" == "true" ]] || arguments+=("--no-online-audits")
 [[ -n "${GHA_ZIZMOR_MIN_SEVERITY}" ]] && arguments+=("--min-severity=${GHA_ZIZMOR_MIN_SEVERITY}")
 [[ -n "${GHA_ZIZMOR_MIN_CONFIDENCE}" ]] && arguments+=("--min-confidence=${GHA_ZIZMOR_MIN_CONFIDENCE}")
+[[ -n "${GHA_ZIZMOR_COLOR}"]] && arguments+=("--color=${GHA_ZIZMOR_COLOR}")
 
 image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION#v}"
 
@@ -60,8 +61,6 @@ image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION#v}"
 #   like '.' resolve correctly.
 # - We pass the GitHub token as an environment variable so that zizmor
 #   can run online audits/perform online collection if requested.
-# - We pass FORCE_COLOR=1 so that the output is always colored, even
-#   though we intentionally don't `docker run -it`.
 # - ${GHA_ZIZMOR_INPUTS} is intentionally not quoted, so that
 #   it can expand according to the shell's word-splitting rules.
 #   However, we put it after `--` so that it can't be interpreted
@@ -73,7 +72,6 @@ docker run \
     --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
     --workdir "/workspace" \
     --env "GH_TOKEN=${GHA_ZIZMOR_TOKEN}" \
-    --env "FORCE_COLOR=1" \
     "${image}" \
     "${arguments[@]}" \
     -- \

--- a/action.yml
+++ b/action.yml
@@ -58,11 +58,9 @@ inputs:
     default: "true"
   color:
     description: |
-      Explicitly control zizmor's colorization behavior.
-
-      This can be 'always' (default), or 'never'.
+      Whether zizmor should output colorized CLI output.
     required: false
-    default: "always"
+    default: "true"
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,13 @@ inputs:
       results to the repository's security tab.
     required: false
     default: "true"
+  color:
+    description: |
+      Explicitly control zizmor's colorization behavior.
+
+      This can be 'always' (default), or 'never'.
+    required: false
+    default: "always"
 
 runs:
   using: composite
@@ -73,6 +80,7 @@ runs:
         GHA_ZIZMOR_VERSION: ${{ inputs.version }}
         GHA_ZIZMOR_TOKEN: ${{ inputs.token }}
         GHA_ZIZMOR_ADVANCED_SECURITY: ${{ inputs.advanced-security }}
+        GHA_ZIZMOR_COLOR: ${{ inputs.color }}
       shell: bash
 
     - name: Upload SARIF file to GitHub Advanced Security


### PR DESCRIPTION
This adds support for the `color` input, which maps to the `--color` parameter for Zizmor. This allows callers to control whether the colorization should happen or not. Fixes #36.

~~I wasn't sure if we wanted to standardize on `color: false` to disable colors, or `color: never` which aligns with `zizmor`'s parameter. I ended up aligning with `zizmor`, but have found it to be slightly confusing for people who are more used to GHA 🤷 I'll let it be up to the maintainer to decide, but am happy to implement whatever we land on.~~
I chose to revert this design. It looks like the rest of the inputs are designed to be inputs to _the action_, not to `zizmor` itself, so it makes more sense to have `color: false` than `color: never` ("never" being nonsensical for the action).

As part of implementing this I have switched from the current hardcoded `FORCE_COLOR=1` env variable to passing `--color=always` by default. As far as I understand this should have no functional difference, other than version support (with `--color` being supported from v1.5.0+ of Zizmor). I'm unsure if that incompatibility with old versions is worth working around.