### PR TITLE
print zizmor version

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -62,6 +62,11 @@ fi
 
 image="ghcr.io/zizmorcore/zizmor:${GHA_ZIZMOR_VERSION#v}"
 
+docker run \
+    --rm \
+    "${image}" \
+    --version
+
 # Notes:
 # - We run the container with ${GITHUB_WORKSPACE} mounted as /workspace
 #   and with /workspace as the working directory, so that user inputs


### PR DESCRIPTION
I saw zizmor failing in https://github.com/release-plz/release-plz/pull/2429 and I thought that knowing what version was the action running was useful for debugging.

Tested in https://github.com/marcoieni/rust-workspace-example/commit/de60c4d9574a02db6921e78a36ffe0cc9fb328ad