### PR TITLE
docs: clarify description of "token" to indicate it is only used for online audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ which will always use the latest version of `zizmor`.
 *Default*: `${{ github.token }}`
 
 `token` is the GitHub token to use for accessing the GitHub REST API
-during online audits, as well as for uploading results to Advanced Security
-when [`advanced-security`](#advanced-security) is enabled.
+during online audits.
 
 ### `advanced-security`
 

--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,7 @@ inputs:
     default: latest
   token:
     description: |
-      The GitHub API token to use for both zizmor and
-      GitHub Advanced Security (if the latter is enabled).
+      The GitHub API token to use for zizmor online-audits (if enabled).
     required: false
     default: ${{ github.token }}
   advanced-security:
@@ -74,7 +73,7 @@ inputs:
   config:
     description: Path to a custom zizmor configuration file Path (e.g., zizmor.yml).
     required: false
-  
+
 
 runs:
   using: composite


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the
      creation of this PR. PRs will not be rejected for using AI tools, but
      *will* be rejected for undisclosed use.

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->
The token parameter is only plumbed to the zizmor binary, but not to the SARIF upload. The distinction is important when using a private GHE server, since the temporal token is not compatible with github.com

Closes #62

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

Action was tested with a private GHE server, using SARIF upload and a PAT for online scans:
```yaml
- name: Run zizmor
  uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
  with:
    persona: pedantic
    token: ${{ secrets.PUBLIC_GH_TOKEN }}
    version: ${{ env.ZIZMOR_VERSION }}
    # do online API queries only on schedule/demand
    online-audits: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
  env:
    # renovate: datasource=pypi depName=zizmor
    ZIZMOR_VERSION: 1.16.3
```
