### PR TITLE
docs: update link to GitHub docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ section!
 >
 > To use workflow failure as a blocking signal, you can use GitHub's rulesets
 > feature. For more information, see
-> [About code scanning alerts - Pull request check failures for code scanning alerts].
+> [Set code scanning merge protection].
 
 > [!NOTE]
 > This is the recommended way to use `zizmor-action` as it provides
@@ -367,7 +367,7 @@ If you hit this behavior, you have a few options:
 
 [`zizmor`]: https://docs.zizmor.sh
 [Advanced Security]: https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security
-[About code scanning alerts - Pull request check failures for code scanning alerts]: https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts#pull-request-check-failures-for-code-scanning-alerts
+[Set code scanning merge protection]: https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/set-code-scanning-merge-protection
 [Input collection]: https://docs.zizmor.sh/usage/#input-collection
 [Audit Rules]: https://docs.zizmor.sh/audits/
 [Using personas]: https://docs.zizmor.sh/usage/#using-personas


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [x] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

I found that the secion `About code scanning alerts - Pull request check failures for code scanning alerts.` on the linked GitHub documentation no longer exists: https://github.com/zizmorcore/zizmor-action/issues/107

This updates the link to point to the new place I found documentation on how to accomplish that.