### PR TITLE
ci: block version sync workflow on forks

### DIFF
--- a/.github/workflows/sync-zizmor-versions.yml
+++ b/.github/workflows/sync-zizmor-versions.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   sync-versions:
     name: Sync zizmor versions
+    if: ${{ github.repository == 'zizmorcore/zizmor-action' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # to create PR branches


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Disables the "Sync zizmor versions" workflow on forks.

Noticed that after the 1.26 release, I started receiving hourly workflow failure emails from my fork ([example run](https://github.com/shaanmajid/zizmor-action/actions/runs/27937932017)) 😅.

## Test Plan

N/A
