### PR TITLE
feat: add zizmor-config input to support centralized configs

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -72,6 +72,11 @@ if [[ -n "${GHA_ZIZMOR_CONFIG:-}" ]]; then
     arguments+=("--config=${GHA_ZIZMOR_CONFIG}")
 fi
 
+if [[ -n "${GHA_ZIZMOR_ZIZMOR_CONFIG:-}" ]]; then
+    echo "${GHA_ZIZMOR_ZIZMOR_CONFIG}" > "${RUNNER_TEMP}/zizmor.yml"
+    arguments+=("--config=/zizmor.yml")
+fi
+
 normalized_version="${GHA_ZIZMOR_VERSION#v}"
 digest="${versions[${normalized_version}]:-}"
 
@@ -103,6 +108,7 @@ echo "::endgroup::"
 docker run \
     --rm \
     --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+    --volume "${RUNNER_TEMP}/zizmor.yml:/zizmor.yml:ro" \
     --workdir "/workspace" \
     --env "GH_TOKEN=${GHA_ZIZMOR_TOKEN}" \
     "${image}" \

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,9 @@ inputs:
   config:
     description: Path to a custom zizmor configuration file Path (e.g., zizmor.yml).
     required: false
+  zizmor-config:
+    description: A custom zizmor configuration YAML.
+    required: false
   fail-on-no-inputs:
     description: |
       Whether the action should fail if no inputs are collected by zizmor.
@@ -120,6 +123,7 @@ runs:
         GHA_ZIZMOR_COLOR: ${{ inputs.color }}
         GHA_ZIZMOR_ANNOTATIONS: ${{ inputs.annotations }}
         GHA_ZIZMOR_CONFIG: ${{ inputs.config }}
+        GHA_ZIZMOR_ZIZMOR_CONFIG: ${{ inputs.zizmor-config }}
         GHA_ZIZMOR_FAIL_ON_NO_INPUTS: ${{ inputs.fail-on-no-inputs }}
       shell: bash
 


### PR DESCRIPTION
## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Currently, passing a custom config to the zizmor action requires creating a config file and providing its path via the 'config' input.

This approach creates friction when enforcing zizmor across all repositories of an organization via rulesets, as it requires duplicating the config file in each repository or invoking the workflow indirectly through another workflow.

Add a 'zizmor-config' input that accepts a static YAML config. This enables centralized config management across repositories.

Closes https://github.com/zizmorcore/zizmor-action/issues/143

## Test Plan

I've tested this in a personal repo: https://github.com/test-ruleset-test-rulset/musical-octo-umbrella/blob/76a68064213780d9cea8323dff41a25698f62a41/.github/workflows/zizmor.yml#L30

(custom config is working and CI is green even though `actions/checkout` is pinned to a tag)
Happy to do more tests

<!-- IMPORTANT: Do not delete the following lines. -->
<!-- @@NUDNIK NEUTRALIZER@@ -->
