### PR TITLE
sync-zizmor-versions: retry up to 5 times

### DIFF
--- a/support/sync-zizmor-versions.sh
+++ b/support/sync-zizmor-versions.sh
@@ -30,6 +30,7 @@ tags=$(skopeo list-tags "docker://${IMAGE}" | jq -r '.Tags[]')
 # and emit it as a line in the format:
 # <tag> <digest>
 for tag in ${tags}; do
-    digest=$(skopeo --override-os=linux --override-arch=amd64  inspect "docker://${IMAGE}:${tag}" | jq -r '.Digest')
+    # Retry up to 5 times, since GHCR is unreliable.
+    digest=$(skopeo --override-os=linux --override-arch=amd64 inspect --retry-times=5 "docker://${IMAGE}:${tag}" | jq -r '.Digest')
     echo "${tag} ${digest}"
 done


### PR DESCRIPTION
`skopeo --retry-times=<N>` will retry up to `N` times, with an exponential backoff by default.

See #153 and #154.

Copilot did a bad job of making a clean PR here.