### PR TITLE
Fall back to uvx when the runner has no Docker daemon

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        # ubuntu-slim has no Docker daemon, so it exercises the uv fallback.
+        os: [ubuntu-latest, ubuntu-24.04-arm, ubuntu-slim]
     runs-on: ${{ matrix.os }}
     permissions:
       security-events: write

--- a/README.md
+++ b/README.md
@@ -329,23 +329,27 @@ security-events: write"}
 
 ## Troubleshooting
 
-### "Cannot run this action without Docker"
+### "Cannot run this action without Docker or uv"
 
-This action uses a container to run `zizmor`, which means that it
-needs access to a container runtime (like Docker).
+This action prefers to run `zizmor` from a container: the image is
+content-addressable, so the action can check it against a known digest,
+and the registry handles multi-arch selection for it.
 
-If you see this error, it _probably_ means that you are running the
-action from a self-hosted runner, or from one of the GitHub-hosted runners
-that does not have Docker installed. For example, the GitHub-hosted
-macOS runners do not have Docker installed by default.
+When the runner has no usable container runtime, the action falls back to
+installing [uv] and running `uvx zizmor@<version>` instead. That covers
+runners without Docker at all, as well as runners like [`ubuntu-slim`],
+which ship the Docker _client_ but no daemon.
 
-For self-hosted runners, you should install Docker (or a compatible
-container runtime) onto the runner.
+If you see this error, then neither path was available &mdash; most likely
+because the `uv` installation step failed. On a self-hosted runner you can
+skip the fallback entirely by installing Docker (or a compatible container
+runtime) onto the runner; [docker/setup-docker-action] may also work on
+other runners, but is **not officially supported** by this action.
 
-For GitHub-hosted runners, you should switch to `ubuntu-latest` or another
-Linux-based runner that comes with Docker by default. You _may_ be
-able to use [docker/setup-docker-action] to install Docker on other runners,
-but this is **not officially supported** by this action.
+> [!NOTE]
+> The fallback has no image digest to check, so it pins the exact `zizmor`
+> version instead and relies on PyPI for artifact integrity. Prefer a runner
+> with a container runtime if that difference matters to you.
 
 ### Changes introduce security alerts but no PR checks are shown
 
@@ -391,6 +395,8 @@ If you hit this behavior, you have a few options:
 [Using personas]: https://docs.zizmor.sh/usage/#using-personas
 [Filtering results]: https://docs.zizmor.sh/usage/#filtering-results
 [docker/setup-docker-action]: https://github.com/docker/setup-docker-action
+[uv]: https://docs.astral.sh/uv/
+[`ubuntu-slim`]: https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md
 [#43]: https://github.com/zizmorcore/zizmor-action/issues/43
 [SARIF support for code scanning]: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#specifying-the-location-for-source-files
 [Triaging code scanning alerts in pull requests]: https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/triaging-code-scanning-alerts-in-pull-requests?utm_source=chatgpt.com#about-code-scanning-results-on-pull-requests

--- a/action.sh
+++ b/action.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# action.sh: run zizmor via Docker
+# action.sh: run zizmor via Docker, or via uvx when Docker is unavailable
 
 set -eu
 
@@ -29,7 +29,14 @@ output() {
     echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
 }
 
-installed docker || die "Cannot run this action without Docker"
+# Selected by bootstrap.sh; `docker` unless the runner has no usable daemon.
+bootstrap="${GHA_ZIZMOR_BOOTSTRAP:-docker}"
+
+case "${bootstrap}" in
+    docker) installed docker || die "Cannot run this action without Docker" ;;
+    uv) installed uv || die "Cannot run this action without Docker or uv" ;;
+    *) die "Unknown bootstrap method: ${bootstrap}" ;;
+esac
 
 [[ "${RUNNER_OS}" != "Linux" ]] && warn "Unsupported runner OS: ${RUNNER_OS}"
 
@@ -78,38 +85,53 @@ digest="${versions[${normalized_version}]:-}"
 # We only proceed if we have a digest for the requested version; a lookup
 # failure indicates an unknown version (i.e. either nonsense or a version
 # that was released after this action's last release).
+#
+# The uv path has no digest to check, but it shares this check so that both
+# paths accept exactly the same set of versions.
 if [[ -z "${digest}" ]]; then
     die "Unknown version: ${GHA_ZIZMOR_VERSION}"
 fi
 
-image="ghcr.io/zizmorcore/zizmor:${normalized_version}@${digest}"
-
-echo "::group::Pulling zizmor image"
-docker pull "${image}"
-echo "::endgroup::"
-
-# Notes:
-# - We run the container with ${GITHUB_WORKSPACE} mounted as /workspace
-#   and with /workspace as the working directory, so that user inputs
-#   like '.' resolve correctly.
+# Notes, for both paths below:
+# - We run from ${GITHUB_WORKSPACE}, so that user inputs like '.' resolve
+#   correctly.
 # - We pass the GitHub token as an environment variable so that zizmor
 #   can run online audits/perform online collection if requested.
 # - ${GHA_ZIZMOR_INPUTS} is intentionally not quoted, so that
 #   it can expand according to the shell's word-splitting rules.
 #   However, we put it after `--` so that it can't be interpreted
 #   as one or more flags.
-#
-# shellcheck disable=SC2086
-docker run \
-    --rm \
-    --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
-    --workdir "/workspace" \
-    --env "GH_TOKEN=${GHA_ZIZMOR_TOKEN}" \
-    "${image}" \
-    "${arguments[@]}" \
-    -- \
-    ${GHA_ZIZMOR_INPUTS} \
-        | tee "${output}"
+if [[ "${bootstrap}" == "docker" ]]; then
+    image="ghcr.io/zizmorcore/zizmor:${normalized_version}@${digest}"
+
+    echo "::group::Pulling zizmor image"
+    docker pull "${image}"
+    echo "::endgroup::"
+
+    # shellcheck disable=SC2086
+    docker run \
+        --rm \
+        --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+        --workdir "/workspace" \
+        --env "GH_TOKEN=${GHA_ZIZMOR_TOKEN}" \
+        "${image}" \
+        "${arguments[@]}" \
+        -- \
+        ${GHA_ZIZMOR_INPUTS} \
+            | tee "${output}"
+else
+    # uvx resolves the right wheel for the runner's architecture itself.
+    # There's no digest to check here, so we lean on the exact version pin
+    # (and on PyPI's own integrity guarantees) instead.
+    cd "${GITHUB_WORKSPACE}"
+
+    # shellcheck disable=SC2086
+    GH_TOKEN="${GHA_ZIZMOR_TOKEN}" uvx "zizmor@${normalized_version}" \
+        "${arguments[@]}" \
+        -- \
+        ${GHA_ZIZMOR_INPUTS} \
+            | tee "${output}"
+fi
 
 exitcode="${PIPESTATUS[0]}"
 dbg "zizmor exited with code ${exitcode}"

--- a/action.yml
+++ b/action.yml
@@ -103,11 +103,26 @@ inputs:
 runs:
   using: composite
   steps:
+    # Docker is the preferred bootstrap: it gives us a content-addressable,
+    # multi-arch image that we can check against a known digest. Some runner
+    # images ship the Docker client without a daemon (`ubuntu-slim`), so we
+    # probe for a *usable* daemon rather than just the client.
+    - name: Select bootstrap method
+      id: bootstrap
+      run: |
+        "${GITHUB_ACTION_PATH}/bootstrap.sh"
+      shell: bash
+
+    - name: Install uv
+      if: ${{ steps.bootstrap.outputs.method == 'uv' }}
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
     - name: Run zizmor
       id: run-zizmor
       run: |
         "${GITHUB_ACTION_PATH}/action.sh"
       env:
+        GHA_ZIZMOR_BOOTSTRAP: ${{ steps.bootstrap.outputs.method }}
         GHA_ZIZMOR_INPUTS: ${{ inputs.inputs }}
         GHA_ZIZMOR_COLLECT: ${{ inputs.collect }}
         GHA_ZIZMOR_ONLINE_AUDITS: ${{ inputs.online-audits }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# bootstrap.sh: decide how `action.sh` should run zizmor
+
+set -eu
+
+warn() {
+    echo "::warning::${*}"
+}
+
+installed() {
+    command -v "${1}" >/dev/null 2>&1
+}
+
+output() {
+    echo "${1}=${2}" >> "${GITHUB_OUTPUT}"
+}
+
+# Docker is preferred: the image is content-addressable, so `action.sh` can
+# check it against a known digest, and it handles multi-arch selection for us.
+#
+# Checking for the client alone isn't enough: `ubuntu-slim` ships the Docker
+# client without a daemon, so `docker pull` there fails with a connection
+# error rather than a missing-command error.
+if installed docker && docker info >/dev/null 2>&1; then
+    output "method" "docker"
+else
+    warn "No usable Docker daemon; falling back to uv to bootstrap zizmor"
+    output "method" "uv"
+fi


### PR DESCRIPTION
Refs #74.

### Problem

`ubuntu-slim` ships the Docker **client** but no daemon, while
`ubuntu-24.04` ships both:

| | ubuntu-24.04 | ubuntu-slim |
| --- | --- | --- |
| Docker Client | 28.0.4 | 29.6.2 |
| Docker Server | 28.0.4 | — |

That gets past the current `installed docker || die` guard, so the action
doesn't fail with its own message — it gets as far as `docker pull` and
fails with a daemon connection error instead.

### Change

* `bootstrap.sh` (new) probes for a *usable* daemon (`docker info`), not just
  the client, and reports the bootstrap method as a step output.
* When no daemon is reachable, the composite action installs `uv` and
  `action.sh` runs `uvx zizmor@<version>` instead of `docker run`.
* Docker stays the preferred path and its behaviour is unchanged, digest
  check included.
* Both paths gate on the same `support/versions` lookup, so they accept
  exactly the same set of versions. The `uv` path has no digest to check,
  so it pins the exact version and relies on PyPI for integrity — this is
  called out in the README.

Besides `ubuntu-slim`, this also makes the action work on runners with no
Docker at all (e.g. the GitHub-hosted macOS runners); the existing
"Unsupported runner OS" warning is untouched.

### Testing

`ubuntu-slim` is added to the selftest matrix, so the fallback is covered by
CI rather than by assertion.

### On the "exactly one bootstrapping mechanism" point

You've said in #74 that you'd rather not maintain two paths, and that you'd
prefer to cut over wholesale when you've settled on a design. This PR is
deliberately narrow in that light: Docker remains the only path on every
runner that can run it, and the second path exists only where the first one
cannot work at all. Two things worth weighing against that:

* it adds a dependency on `astral-sh/setup-uv`, and
* `uv` is *not* preinstalled on `ubuntu-slim` (pipx is, at 1.16.3, if you'd
  prefer the zero-bootstrap option you noted in #74).

Happy to rework this as a full cutover, switch the fallback to pipx, or
close it if you'd rather wait for the single-mechanism switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiacQ5MSzv4x9oLPeZvYDL
